### PR TITLE
Add simple touch-friendly Tetris example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Derleme çıktısı `docs` klasörüne alınır. GitHub Pages üzerinden ön izl
 https://<kullanici-adi>.github.io/khb_1/
 ```
 
+## Mini Tetris Oyunu
+
+Depoya örnek olarak basit bir tek elle oynanabilir Tetris oyunu eklendi. `tetris.html` dosyasını tarayıcınızda açarak oyunu deneyebilirsiniz. Dokunarak döndürün, yatay sürükleyerek hareket ettirin ve aşağı doğru sürükleyerek parçayı bırakın.
+
 ## Lisans
 
 GPL lisansı ile yayınlanmıştır.

--- a/tetris.html
+++ b/tetris.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mini Tetris</title>
+  <style>
+    body { margin:0; display:flex; justify-content:center; align-items:center; height:100vh; background:#111; color:#fff; font-family:sans-serif; }
+    canvas { border:1px solid #555; background:#000; touch-action:none; }
+  </style>
+</head>
+<body>
+  <canvas id="game" width="200" height="400"></canvas>
+  <script type="module" src="tetris.js"></script>
+</body>
+</html>

--- a/tetris.js
+++ b/tetris.js
@@ -1,0 +1,243 @@
+const canvas = document.getElementById('game');
+const context = canvas.getContext('2d');
+context.scale(20, 20);
+
+const COLS = 10;
+const ROWS = 20;
+
+const arena = createMatrix(COLS, ROWS);
+let dropCounter = 0;
+let dropInterval = 1000;
+let lastTime = 0;
+
+const player = {
+  pos: { x: 0, y: 0 },
+  matrix: null,
+  score: 0,
+};
+
+function createMatrix(w, h) {
+  const matrix = [];
+  while (h--) {
+    matrix.push(new Array(w).fill(0));
+  }
+  return matrix;
+}
+
+function createPiece(type) {
+  switch (type) {
+    case 'T':
+      return [
+        [0, 0, 0],
+        [1, 1, 1],
+        [0, 1, 0],
+      ];
+    case 'O':
+      return [
+        [2, 2],
+        [2, 2],
+      ];
+    case 'L':
+      return [
+        [0, 3, 0],
+        [0, 3, 0],
+        [0, 3, 3],
+      ];
+    case 'J':
+      return [
+        [0, 4, 0],
+        [0, 4, 0],
+        [4, 4, 0],
+      ];
+    case 'I':
+      return [
+        [0, 5, 0, 0],
+        [0, 5, 0, 0],
+        [0, 5, 0, 0],
+        [0, 5, 0, 0],
+      ];
+    case 'S':
+      return [
+        [0, 6, 6],
+        [6, 6, 0],
+        [0, 0, 0],
+      ];
+    case 'Z':
+      return [
+        [7, 7, 0],
+        [0, 7, 7],
+        [0, 0, 0],
+      ];
+  }
+}
+
+function collide(arena, player) {
+  const m = player.matrix;
+  const o = player.pos;
+  for (let y = 0; y < m.length; ++y) {
+    for (let x = 0; x < m[y].length; ++x) {
+      if (m[y][x] !== 0 &&
+          (arena[y + o.y] && arena[y + o.y][x + o.x]) !== 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function merge(arena, player) {
+  player.matrix.forEach((row, y) => {
+    row.forEach((value, x) => {
+      if (value !== 0) {
+        arena[y + player.pos.y][x + player.pos.x] = value;
+      }
+    });
+  });
+}
+
+function rotate(matrix, dir) {
+  for (let y = 0; y < matrix.length; ++y) {
+    for (let x = 0; x < y; ++x) {
+      [matrix[x][y], matrix[y][x]] = [matrix[y][x], matrix[x][y]];
+    }
+  }
+  if (dir > 0) {
+    matrix.forEach(row => row.reverse());
+  } else {
+    matrix.reverse();
+  }
+}
+
+function playerDrop() {
+  player.pos.y++;
+  if (collide(arena, player)) {
+    player.pos.y--;
+    merge(arena, player);
+    playerReset();
+    arenaSweep();
+    updateScore();
+  }
+  dropCounter = 0;
+}
+
+function playerMove(dir) {
+  player.pos.x += dir;
+  if (collide(arena, player)) {
+    player.pos.x -= dir;
+  }
+}
+
+function playerReset() {
+  const pieces = 'TJLOSZI';
+  player.matrix = createPiece(pieces[(pieces.length * Math.random()) | 0]);
+  player.pos.y = 0;
+  player.pos.x = ((COLS / 2) | 0) - ((player.matrix[0].length / 2) | 0);
+  if (collide(arena, player)) {
+    arena.forEach(row => row.fill(0));
+    player.score = 0;
+    updateScore();
+  }
+}
+
+function playerRotate(dir) {
+  const pos = player.pos.x;
+  let offset = 1;
+  rotate(player.matrix, dir);
+  while (collide(arena, player)) {
+    player.pos.x += offset;
+    offset = -(offset + (offset > 0 ? 1 : -1));
+    if (offset > player.matrix[0].length) {
+      rotate(player.matrix, -dir);
+      player.pos.x = pos;
+      return;
+    }
+  }
+}
+
+function arenaSweep() {
+  outer: for (let y = arena.length - 1; y > 0; --y) {
+    for (let x = 0; x < arena[y].length; ++x) {
+      if (arena[y][x] === 0) {
+        continue outer;
+      }
+    }
+    const row = arena.splice(y, 1)[0].fill(0);
+    arena.unshift(row);
+    ++y;
+    player.score += 10;
+  }
+}
+
+function update(time = 0) {
+  const deltaTime = time - lastTime;
+  lastTime = time;
+  dropCounter += deltaTime;
+  if (dropCounter > dropInterval) {
+    playerDrop();
+  }
+  draw();
+  requestAnimationFrame(update);
+}
+
+function draw() {
+  context.fillStyle = '#000';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  drawMatrix(arena, { x: 0, y: 0 });
+  drawMatrix(player.matrix, player.pos);
+}
+
+function drawMatrix(matrix, offset) {
+  const colors = [null, '#f0f', '#ff0', '#0ff', '#f90', '#0f0', '#00f', '#f00'];
+  matrix.forEach((row, y) => {
+    row.forEach((value, x) => {
+      if (value !== 0) {
+        context.fillStyle = colors[value];
+        context.fillRect(x + offset.x, y + offset.y, 1, 1);
+      }
+    });
+  });
+}
+
+function updateScore() {
+  document.title = `Score: ${player.score}`;
+}
+
+let touchStart = null;
+canvas.addEventListener('touchstart', e => {
+  touchStart = e.touches[0];
+});
+
+canvas.addEventListener('touchend', e => {
+  if (!touchStart) return;
+  const end = e.changedTouches[0];
+  const dx = end.clientX - touchStart.clientX;
+  const dy = end.clientY - touchStart.clientY;
+  const absX = Math.abs(dx);
+  const absY = Math.abs(dy);
+  if (absX < 10 && absY < 10) {
+    playerRotate(1);
+  } else if (absX > absY) {
+    playerMove(dx > 0 ? 1 : -1);
+  } else if (dy > 0) {
+    playerDrop();
+  }
+  touchStart = null;
+});
+
+window.addEventListener('keydown', event => {
+  if (event.keyCode === 37) {
+    playerMove(-1);
+  } else if (event.keyCode === 39) {
+    playerMove(1);
+  } else if (event.keyCode === 40) {
+    playerDrop();
+  } else if (event.keyCode === 81) {
+    playerRotate(-1);
+  } else if (event.keyCode === 38 || event.keyCode === 87) {
+    playerRotate(1);
+  }
+});
+
+playerReset();
+updateScore();
+update();


### PR DESCRIPTION
## Summary
- add standalone `tetris.html` with canvas and script loader
- implement `tetris.js` featuring basic Tetris mechanics and one-finger touch controls
- document how to try the mini game in the README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a73dfd0ea08324a17ad775c2c1a662