### PR TITLE
feat: add game over overlay and update key handling

### DIFF
--- a/tetris.html
+++ b/tetris.html
@@ -7,10 +7,16 @@
   <style>
     body { margin:0; display:flex; justify-content:center; align-items:center; height:100vh; background:#111; color:#fff; font-family:sans-serif; }
     canvas { border:1px solid #555; background:#000; touch-action:none; }
+    #game-over { position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.8); display:none; flex-direction:column; align-items:center; justify-content:center; }
+    #game-over button { margin-top:1rem; padding:0.5rem 1rem; }
   </style>
 </head>
 <body>
   <canvas id="game" width="200" height="400"></canvas>
+  <div id="game-over">
+    <div>Game Over</div>
+    <button id="play-again">Play Again</button>
+  </div>
   <script type="module" src="tetris.js"></script>
 </body>
 </html>

--- a/tetris.js
+++ b/tetris.js
@@ -2,6 +2,10 @@ const canvas = document.getElementById('game');
 const context = canvas.getContext('2d');
 context.scale(20, 20);
 
+const overlay = document.getElementById('game-over');
+const playAgainButton = document.getElementById('play-again');
+let gameOver = false;
+
 const COLS = 10;
 const ROWS = 20;
 
@@ -133,9 +137,8 @@ function playerReset() {
   player.pos.y = 0;
   player.pos.x = ((COLS / 2) | 0) - ((player.matrix[0].length / 2) | 0);
   if (collide(arena, player)) {
-    arena.forEach(row => row.fill(0));
-    player.score = 0;
-    updateScore();
+    gameOver = true;
+    overlay.style.display = 'flex';
   }
 }
 
@@ -176,7 +179,9 @@ function update(time = 0) {
     playerDrop();
   }
   draw();
-  requestAnimationFrame(update);
+  if (!gameOver) {
+    requestAnimationFrame(update);
+  }
 }
 
 function draw() {
@@ -225,17 +230,27 @@ canvas.addEventListener('touchend', e => {
 });
 
 window.addEventListener('keydown', event => {
-  if (event.keyCode === 37) {
+  if (event.key === 'ArrowLeft') {
     playerMove(-1);
-  } else if (event.keyCode === 39) {
+  } else if (event.key === 'ArrowRight') {
     playerMove(1);
-  } else if (event.keyCode === 40) {
+  } else if (event.key === 'ArrowDown') {
     playerDrop();
-  } else if (event.keyCode === 81) {
+  } else if (event.key === 'q' || event.key === 'Q') {
     playerRotate(-1);
-  } else if (event.keyCode === 38 || event.keyCode === 87) {
+  } else if (event.key === 'ArrowUp' || event.key === 'w' || event.key === 'W') {
     playerRotate(1);
   }
+});
+
+playAgainButton.addEventListener('click', () => {
+  overlay.style.display = 'none';
+  arena.forEach(row => row.fill(0));
+  player.score = 0;
+  updateScore();
+  gameOver = false;
+  playerReset();
+  update();
 });
 
 playerReset();


### PR DESCRIPTION
## Summary
- replace deprecated `keyCode` checks with `event.key` for keyboard controls
- add a simple game-over overlay with a restart button that resets and restarts gameplay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a77dfaf8ec8324b978962357238f42